### PR TITLE
Bugs fixed in shell mechanics formulation

### DIFF
--- a/Code/Source/svFSI/BAFINI.f
+++ b/Code/Source/svFSI/BAFINI.f
@@ -582,7 +582,7 @@
       END SUBROUTINE FSILSINI
 !####################################################################
 !     Compute shell extended IEN for triangular elements. Reqd. to
-!     resolve bending moments
+!     resolve bending moments.
       SUBROUTINE SETSHLXIEN(lM)
       USE COMMOD
       IMPLICIT NONE
@@ -697,7 +697,7 @@
       RETURN
       END SUBROUTINE SHLINI
 !--------------------------------------------------------------------
-!     Initializing shell boundary condition variables
+!     Initializing boundary condition variables for CST shells
       SUBROUTINE SHLBCINI(lBc, lFa, lM)
       USE COMMOD
       USE ALLFUN
@@ -709,7 +709,7 @@
       INTEGER(KIND=IKIND) :: a, b, e, Ac, Bc, Ec
       LOGICAL :: bFlag
 
-      IF (lFa%eType .EQ. eType_NRB) RETURN
+      IF (lFa%eType .NE. eType_TRI3) RETURN
       DO e=1, lFa%nEl
          Ec = lFa%gE(e)
          DO a=1, lM%eNoN

--- a/Code/Source/svFSI/BF.f
+++ b/Code/Source/svFSI/BF.f
@@ -176,7 +176,7 @@
          Nx = lM%Nx(:,:,g)
          SELECT CASE (cPhys)
          CASE (phys_shell)
-            CALL SHELLFP(eNoN, w, N, Nx, dl, xl, bfl, lR, lK)
+            CALL SHELLBF(eNoN, w, N, Nx, dl, xl, bfl, lR, lK)
 
          CASE (phys_CMM)
             CALL BCMMi(eNoN, idof, w, N, Nx, xl, bfl, lR)

--- a/Code/Source/svFSI/INITIALIZE.f
+++ b/Code/Source/svFSI/INITIALIZE.f
@@ -171,12 +171,12 @@
       IF (shlEq) THEN
          DO iM=1, nMsh
             IF (msh(iM)%lShl) THEN
-               IF (msh(iM)%eType .EQ. eType_NRB) THEN
+               IF (msh(iM)%eType .EQ. eType_TRI3) THEN
+                  CALL SETSHLXIEN(msh(iM))
+               ELSE
                   ALLOCATE(msh(iM)%eIEN(0,0))
                   ALLOCATE(msh(iM)%sbc(msh(iM)%eNoN,msh(iM)%nEl))
                   msh(iM)%sbc = 0
-               ELSE IF (msh(iM)%eType .EQ. eType_TRI3) THEN
-                  CALL SETSHLXIEN(msh(iM))
                END IF
             END IF
          END DO

--- a/Code/Source/svFSI/LHSA.f
+++ b/Code/Source/svFSI/LHSA.f
@@ -74,7 +74,7 @@
 !     Treat shells with triangular elements here
       DO iM=1, nMsh
          IF (.NOT.shlEq .OR. .NOT.msh(iM)%lShl) CYCLE
-         IF (msh(iM)%eType .EQ. eType_NRB) CYCLE
+         IF (msh(iM)%eType .NE. eType_TRI3) CYCLE
          DO e=1, msh(iM)%nEl
             DO a=1, 2*msh(iM)%eNoN
                IF (a .LE. msh(iM)%eNoN) THEN

--- a/Code/Source/svFSI/NN.f
+++ b/Code/Source/svFSI/NN.f
@@ -1264,7 +1264,7 @@ c        N(8) = lx*my*0.5_RKIND
       END SUBROUTINE GETGNN
 !--------------------------------------------------------------------
 !     Returns second order derivatives at given natural coords
-      SUBROUTINE GETGNNxx(insd, ind2, eType, eNoN, xi, Nxx)
+      PURE SUBROUTINE GETGNNxx(insd, ind2, eType, eNoN, xi, Nxx)
       USE COMMOD
       IMPLICIT NONE
       INTEGER(KIND=IKIND), INTENT(IN) :: insd, ind2, eType, eNoN
@@ -1608,7 +1608,7 @@ c        N(8) = lx*my*0.5_RKIND
             B(3,a) = Nxi2(3,a) - Nx(1,a)*xXi2(1,3) - Nx(2,a)*xXi2(2,3)
          END DO
 
-         CALL DGESV(l,eNoN,K,l,IPIV,B,l,INFO)
+         CALL DGESV(l, eNoN, K, l, IPIV, B, l, INFO)
          IF (INFO .NE. 0) err = "Error in Lapack @ GNNxx."
          Nxx = B
 
@@ -1703,10 +1703,10 @@ c        N(8) = lx*my*0.5_RKIND
       END DO
       nV = CROSS(xXi)
 
-!     Covariant basis
+!     Covariant basis, g_a
       gCov = xXi
 
-!     Metric tensor g_i . g_j
+!     Metric tensor g_a . g_b
       Gmat = 0._RKIND
       DO i=1, insd
          DO j=1, insd
@@ -1933,12 +1933,12 @@ c        N(8) = lx*my*0.5_RKIND
 !        Update shape functions if NURBS
          IF (msh(iM)%eType .EQ. eType_NRB) CALL NRBNNX(msh(iM), Ec)
 
-!        Compute adjoining mesh element normal
-         ALLOCATE(xXi(nsd,insd))
+!        Compute normal of the adjoining mesh element
+         ALLOCATE(xXi(nsd,nsd-1))
          xXi = 0._RKIND
          DO a=1, eNoN
-            DO i=1, insd
-               xXi(:,i) = xXi(:,i) + lX(:,a)*msh(iM)%Nx(i,a,g)
+            DO i=1, nsd-1
+               xXi(:,i) = xXi(:,i) + lX(:,a)*msh(iM)%Nx(i,a,1)
             END DO
          END DO
          v(:) = CROSS(xXi)
@@ -1959,7 +1959,7 @@ c        N(8) = lx*my*0.5_RKIND
          n(3) = v(1)*xXi(2,1) - v(2)*xXi(1,1)
 
 !        I choose Gauss point of the mesh element for calculating
-!        interior edge
+!        interior edge vector.
          v(:) = 0._RKIND
          DO a=1, eNoN
             v(:) = v(:) + lX(:,a)*msh(iM)%N(a,g)

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -92,7 +92,7 @@
 
          IF (dFlag) THEN
             IF (.NOT.sstEq) THEN
-!              struct, lElas, FSI (struct, mesh)
+!              struct, lElas, shells, FSI (struct, mesh)
                coef = dt*dt*(0.5_RKIND*eq(iEq)%gam - eq(iEq)%beta)
      2            /(eq(iEq)%gam - 1._RKIND)
                Dn(s:e,:) = Do(s:e,:) + Yn(s:e,:)*dt + An(s:e,:)*coef

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -1835,7 +1835,7 @@
 
 !     Read BCs for shells with triangular elements. Not necessary for
 !     NURBS elements
-      lPtr => list%get(ctmp,"Shell BC type")
+      lPtr => list%get(ctmp,"CST shell BC type")
       IF (ASSOCIATED(lPtr)) THEN
          SELECT CASE (ctmp)
          CASE ("Fixed", "fixed", "Clamped", "clamped")

--- a/Code/Source/svFSI/READMSH.f
+++ b/Code/Source/svFSI/READMSH.f
@@ -129,13 +129,12 @@
          ALLOCATE(x(nsd,gtnNo))
          x = gX
 
-!        Checks for shell elements
+!     Checks for shell elements
          DO iM=1, nMsh
             IF (msh(iM)%lShl) THEN
-               IF (msh(iM)%eType.NE.eType_NRB .AND.
-     2             msh(iM)%eType.NE.eType_TRI3) THEN
-                  err = "Shell elements can be either triangles "//
-     2               "or C1-NURBS"
+               IF (msh(iM)%eType .EQ. eType_QUD4) THEN
+                  err = "Shell elements cannot be bilinear quads. "//
+     2               "Use higher-order quads, triangles, or NURBS."
                END IF
                IF (msh(iM)%eType .EQ. eType_NRB) THEN
                   DO i=1, nsd-1
@@ -143,10 +142,10 @@
      2                  "NURBS for shell elements should be p > 1"
                   END DO
                END IF
-c               IF (msh(iM)%eType .EQ. eType_TRI) THEN
-c                  IF (.NOT.cm%seq()) err = "Triangular shell elements"//
-c     2               " should be run sequentially"
-c               END IF
+               IF (msh(iM)%eType .EQ. eType_TRI3) THEN
+                  IF (.NOT.cm%seq()) err = "Shells with linear "//
+     2               "triangles should be run sequentially"
+               END IF
             END IF
          END DO
 
@@ -342,7 +341,6 @@ c               END IF
             EXIT
          END IF
       END DO
-
       IF (flag) THEN
          DO iM=1, nMsh
             lPM => list%get(msh(iM)%name,"Add mesh",iM)

--- a/Code/Source/svFSI/VTKXML.f
+++ b/Code/Source/svFSI/VTKXML.f
@@ -1087,6 +1087,7 @@
 
       clcDmn = .FALSE.
       IF (.NOT.savedOnce) THEN
+         IF (ALLOCATED(d%xe)) DEALLOCATE(d%xe)
          ALLOCATE(d%xe(d%nEl,2))
          IF (cm%mas()) THEN
 !     Based on the two posible fields


### PR DESCRIPTION
A few bugs were fixed for the nonlinear shell mechanics formulation
with 3-noded constant strain triangles. Tested on plate bending and
aortic-valve mechanics simulation.

Commit also includes few cosmetic changes.

TODO:
- Postprocessing element data for NURBS need to be updated
- Shells for higher order elements (tri6, quad8/quad9) need to be
verified
- Shell formulation should be upgraded for hyperelastic material models